### PR TITLE
Update accent color

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
       loadSidebar: true,
       subMaxLevel: 3,
       coverpage: true,
+      themeColor: '#136893',
       name: 'Institutional Plan',
       repo: 'https://github.com/MakeSchool/institutional-plan',
     }


### PR DESCRIPTION
I noticed that the website still uses the default green accent color provided by docsify. So, I went ahead and updated the docsify config with the accent color that is used in course websites --> [make.sc/cs1.3](https://make-school-courses.github.io/CS-1.3-Core-Data-Structures/#/).